### PR TITLE
Prepare for 0.2.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
           version: '0.8.156'
 
       - name: Build static site
-        run: bb publish-gh-pages
+        run: bb build-static
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.2.0 [unreleased]
+## [unreleased]
+
+## 0.2.0
 
 - #8:
 

--- a/bb.edn
+++ b/bb.edn
@@ -13,7 +13,7 @@
    :task
    (shell "clojure -X:dev:nextjournal/clerk user/start!")}
 
-  publish-gh-pages
+  build-static
   {:doc "Generate a fresh static build."
    :task
    (do (shell "npm ci")
@@ -31,14 +31,14 @@
   {:doc "Generate a fresh static build and release it to Github Pages."
    :task
    (do (shell "rm -rf public")
-       (run 'publish-gh-pages)
+       (run 'build-gh-pages)
        (shell "npm run gh-pages"))}
 
   publish-local
   {:doc "Generate a fresh static build in the `public` folder and start a local
   webserver."
    :task
-   (do (run 'publish-gh-pages)
+   (do (run 'build-static)
        (shell "npm run serve"))}
 
   release

--- a/build.clj
+++ b/build.clj
@@ -5,7 +5,7 @@
 ;; ## Variables
 
 (def lib 'org.mentat/clerk-utils)
-(def version "0.2.0-SNAPSHOT")
+(def version "0.2.0")
 
 (defn- ->version
   ([] version)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -13,6 +13,7 @@
 
 (def build-target
   {:index index
+   :git/url "https://github.com/mentat-collective/clerk-utils"
    :paths ["dev/clerk_utils/show.cljc"]})
 
 (def ^{:doc "static site defaults for local and github-pages modes."}
@@ -39,16 +40,22 @@
   (Thread/sleep 500)
   (clerk/show! index))
 
+(defn git-sha
+  "Returns the sha hash of this project's current git revision."
+  []
+  (-> (sh "git" "rev-parse" "HEAD")
+      (:out)
+      (clojure.string/trim)))
+
 (defn replace-sha-template!
   "Given some `path`, modifies the file at `path` replaces any occurence of the
   string `$GIT_SHA` with the actual current sha of the repo."
-  [path]
-  (let [sha (-> (sh "git" "rev-parse" "HEAD")
-                (:out)
-                (clojure.string/trim))]
-    (-> (slurp path)
-        (clojure.string/replace "$GIT_SHA" sha)
-        (->> (spit path)))))
+  ([path]
+   (replace-sha-template! path (git-sha)))
+  ([path sha]
+   (-> (slurp path)
+       (clojure.string/replace "$GIT_SHA" sha)
+       (->> (spit path)))))
 
 (defn static-build!
   "This task is used to generate static sites for local use, github pages
@@ -71,6 +78,7 @@
   All `opts` are forwarded to [[nextjournal.clerk/build!]]."
   [opts]
   (let [{:keys [out-path cas-prefix]} (merge defaults opts)
+        sha (or (:git/sha opts) (git-sha))
         cas (cv/store+get-cas-url!
              {:out-path (str out-path "/js") :ext "js"}
              (fs/read-all-bytes "public/js/main.js"))]
@@ -79,9 +87,11 @@
            (str cas-prefix "js/" cas))
     (clerk/build!
      (merge build-target
-            (assoc opts :out-path out-path)))
+            (assoc opts :out-path out-path
+                   :git/sha sha)))
     (replace-sha-template!
-     (str out-path "/index.html"))))
+     (str out-path "/index.html")
+     sha)))
 
 (defn garden!
   "Standalone executable function that runs [[static-build!]] configured for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "clerk-utils",
-  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This PR adds `:git/sha` and `:git/url` options at Martin's suggestion, and renames `publish-gh-pages` to `build-static`.