### PR TITLE
Fix template docstring, install instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- #:
+- #16:
 
   - Fix broken deps reference in `clerk-utils/custom` template instructions
     (closes #15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [unreleased]
 
+- #:
+
+  - Fix broken deps reference in `clerk-utils/custom` template instructions
+    (closes #15)
+
+  - In `mentat.clerk-utils.build/serve!`, call `clerk/show!` before
+    `clerk/serve!` to prevent flashing loading screen, if an index is supplied.
+
+  - Fix incorrect docstrings in project template `bb.edn`
+
+  - Add `config.edn` to `clerk-utils/custom` template, so that future
+    `clj-kondo` commands (like `--copy-config` calls etc) work.
+
 ## [0.3.0]
 
 - #13:

--- a/resources/clerk_utils/custom/README.md
+++ b/resources/clerk_utils/custom/README.md
@@ -15,7 +15,7 @@ clojure -Ttools install io.github.seancorfield/deps-new '{:git/tag "v0.4.13"}' :
 Then create a project using the `clerk-utils/custom` template:
 
 ```
-clojure -Sdeps '{:deps {io.github.mentat-collective/clerk-utils {:git/tag "v0.3.0"}}}' \
+clojure -Sdeps '{:deps {io.github.mentat-collective/clerk-utils {:git/sha "582c804b90086ab3d0ed31b3b4777df79bf0baa6"}}}' \
 -Tnew create \
 :template clerk-utils/custom \
 :name myusername/my-notebook-project
@@ -30,6 +30,10 @@ mentat-collective/clerk-utils-custom-template`.
 > `org_name/project_name`) where you expect to host the project. The above
 > command will create a new project in the folder `my-notebook-project` in the
 > directory where you run the command.
+>
+> To use a different version of the template, replace the `:git/sha` above with
+> the sha of version you need from the [Clerk-Utils commit
+> history](https://github.com/mentat-collective/Clerk-Utils/commits/main).
 
 The generated project will contains more guides and information in its
 `README.md` and in the generated Clerk notebook.

--- a/resources/clerk_utils/custom/root/.clj-kondo/config.edn
+++ b/resources/clerk_utils/custom/root/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:lint-as
+ {reagent.core/with-let clojure.core/let}}

--- a/resources/clerk_utils/custom/root/bb.edn
+++ b/resources/clerk_utils/custom/root/bb.edn
@@ -16,7 +16,7 @@
                 (System/exit 1))))))
 
   clerk-watch
-  {:doc "Start a shadow-cljs watch process that generates this project's custom JS."
+  {:doc "Runs clerk/serve! with a watcher process generating custom JS."
    :task (X "clojure -X:nextjournal/clerk user/serve!")}
 
   build-static
@@ -42,13 +42,12 @@
        (shell "npm run gh-pages"))}
 
   publish-local
-  {:doc "Generate a fresh static build in the `public` folder and start a local
-  webserver."
+  {:doc "Generate a fresh static build and start a local webserver."
    :task
    (do (run 'build-static)
        (run 'serve))}
 
   lint
-  {:doc "Lint the src and dev directories with clj-kondo."
+  {:doc "Lint all code directories with clj-kondo."
    :task (clj-kondo/print!
           (clj-kondo/run! {:lint ["src" "dev" "notebooks"]}))}}}

--- a/src/mentat/clerk_utils/build.clj
+++ b/src/mentat/clerk_utils/build.clj
@@ -72,10 +72,9 @@
   (when (seq cljs-namespaces)
     (let [{:keys [js-url]} (shadow/watch! cljs-namespaces)]
       (set-viewer-js! js-url)))
-  (try (clerk/serve! opts)
-       (finally
-         (when (and browse? index)
-           (clerk/show! index)))))
+  (when (and browse? index)
+    (clerk/show! index))
+  (clerk/serve! opts))
 
 (defn halt!
   "Version of [[nextjournal.clerk/halt!]] that additionally kills any shadow-cljs


### PR DESCRIPTION
  - Fix broken deps reference in `clerk-utils/custom` template instructions
    (closes #15)

  - In `mentat.clerk-utils.build/serve!`, call `clerk/show!` before
    `clerk/serve!` to prevent flashing loading screen, if an index is supplied.

  - Fix incorrect docstrings in project template `bb.edn`

  - Add `config.edn` to `clerk-utils/custom` template, so that future
    `clj-kondo` commands (like `--copy-config` calls etc) work.