### PR TITLE
Docs upgrades, add test target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: Clojure Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: latest
+
+      - name: Install babashka
+        uses: just-sultanov/setup-babashka@v2
+        with:
+          version: '0.8.156'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Install dependencies
+        run: clojure -P -M:test
+
+      - name: Clojure tests
+        run: bb test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [0.4.0]
 
+- #21:
+
+  - Adds `bb test`, GitHub Action for tests and the `deps.edn` entry required to
+    make it work.
+
+  - Fixes a `j/` alias left over in `mentat.clerk-utils.show/loading-viewer`;
+    these aliases aren't available in the latest Clerk SCI environment, and need
+    to be fully expanded.
+
 - #19:
 
   - Upgrades to Clerk version `fad499407d979916d21b33cc7e46e73f7a485e37`

--- a/bb.edn
+++ b/bb.edn
@@ -51,6 +51,10 @@
   {:doc "Release the library to Clojars."
    :task (shell "clojure -T:build publish")}
 
+  test
+  {:doc "Run Clojure tests."
+   :task (shell "clojure -X:test")}
+
   lint
   {:doc "Lint all code directories with clj-kondo."
    :task (clj-kondo/print!

--- a/deps.edn
+++ b/deps.edn
@@ -20,6 +20,14 @@
      :deps/root "render"}}
    :exec-fn user/build!}
 
+  :test
+  {:extra-paths ["test"]
+   :extra-deps
+   {io.github.cognitect-labs/test-runner
+    {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts ["-m" "cognitect.test-runner"]
+   :exec-fn cognitect.test-runner.api/test}
+
   :build
   {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}
           slipset/deps-deploy {:mvn/version "0.2.0"}}

--- a/dev/clerk_utils/notebook.clj
+++ b/dev/clerk_utils/notebook.clj
@@ -378,7 +378,7 @@ clojure -Sdeps '{:deps {io.github.mentat-collective/clerk-utils {:git/sha \"%s\"
 :name myusername/my-notebook-project
 ```" (docs/git-sha)))
 
-;; The README.md file in the generated project contains information on how to
+;; The `README.md` file in the generated project contains information on how to
 ;; extend and develop within the new project.
 
 ;; If you have an existing Clerk notebook project and are considering adding

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "@codemirror/autocomplete": "6.4.1",
+        "@codemirror/autocomplete": "6.4.2",
         "@codemirror/commands": "6.2.1",
         "@codemirror/lang-markdown": "6.0.0",
         "@codemirror/language": "6.6.0",
         "@codemirror/lint": "6.1.1",
         "@codemirror/search": "6.2.3",
         "@codemirror/state": "6.2.0",
-        "@codemirror/view": "6.9.0",
+        "@codemirror/view": "6.9.1",
         "@lezer/common": "1.0.2",
         "@lezer/generator": "1.2.2",
         "@lezer/highlight": "1.1.3",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.1.tgz",
-      "integrity": "sha512-06yAmj0FjPZzYOpNeugJtG28GNqU2/CPr34m91Q+fKSyTOR6+hDFiatkPcIkxOlU0K5yP7WH6KoLg3fTqIUgaw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz",
+      "integrity": "sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -161,9 +161,9 @@
       "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
     },
     "node_modules/@codemirror/view": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.0.tgz",
-      "integrity": "sha512-uFaqE6fBOp0Dj/tmWoe/TFlSSIPdpAzhvATgbq1eAKRkgq3hY79FioZ7nfdiT+24kz68AIWuSZ9hi3psKe36WQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.1.tgz",
+      "integrity": "sha512-bzfSjJn9dAADVpabLKWKNmMG4ibyTV2e3eOGowjElNPTdTkSbi6ixPYHm2u0ADcETfKsi2/R84Rkmi91dH9yEg==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -1790,9 +1790,9 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.1.tgz",
-      "integrity": "sha512-06yAmj0FjPZzYOpNeugJtG28GNqU2/CPr34m91Q+fKSyTOR6+hDFiatkPcIkxOlU0K5yP7WH6KoLg3fTqIUgaw==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz",
+      "integrity": "sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1904,9 +1904,9 @@
       "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
     },
     "@codemirror/view": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.0.tgz",
-      "integrity": "sha512-uFaqE6fBOp0Dj/tmWoe/TFlSSIPdpAzhvATgbq1eAKRkgq3hY79FioZ7nfdiT+24kz68AIWuSZ9hi3psKe36WQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.1.tgz",
+      "integrity": "sha512-bzfSjJn9dAADVpabLKWKNmMG4ibyTV2e3eOGowjElNPTdTkSbi6ixPYHm2u0ADcETfKsi2/R84Rkmi91dH9yEg==",
       "requires": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "gh-pages": "gh-pages -d public/build --dotfiles true"
   },
   "dependencies": {
-    "@codemirror/autocomplete": "6.4.1",
+    "@codemirror/autocomplete": "6.4.2",
     "@codemirror/commands": "6.2.1",
     "@codemirror/lang-markdown": "6.0.0",
     "@codemirror/language": "6.6.0",
     "@codemirror/lint": "6.1.1",
     "@codemirror/search": "6.2.3",
     "@codemirror/state": "6.2.0",
-    "@codemirror/view": "6.9.0",
+    "@codemirror/view": "6.9.1",
     "@lezer/common": "1.0.2",
     "@lezer/generator": "1.2.2",
     "@lezer/highlight": "1.1.3",

--- a/resources/clerk_utils/custom/README.md
+++ b/resources/clerk_utils/custom/README.md
@@ -45,30 +45,30 @@ about this template.
 ## Template Keyword Options
 
 You can customize the `clerk-utils/custom` template by supplying any of the
-following key-value pairs to the above command (default values in parentheses):
+following key-value pairs to the above command (See
+[`template.edn`][template-edn-url] for default values):
 
 - `:description`: This string is inserted at the top of your generated project's
   README.md.
-- `:clerk-port`: (`7777`) the port used by `clerk/serve!` during interactive
+- `:clerk-port`: the port used by `clerk/serve!` during interactive
   development.
-- `:clerk-sha`: (`"4180ed31c2864687a770f6d4f625303bd8e75437"`) the hash of the
-  Clerk version you'd like to use in the template. (`clerk-utils/custom` uses a
-  [git dependency](https://clojure.org/news/2018/01/05/git-deps) for Clerk.)
-- `:shadow-port`: (`8765`) the port that [`shadow-cljs`][shadow-url] uses to
-  serve compiled JavaScript during interactive development.
-- `:shadow-version`: (`"2.20.14"`) the version of [`shadow-cljs`][shadow-url]
-  required by the generated project.
-- `:clj-version`: (`"1.11.1"`) the version of Clojure required by the generated
-  project.
-- `:cljs-version`: (`"1.11.60"`) the version of ClojureScript required by the
-  generated project. (_note that this needs to meet or exceed the version
-  declared in the [`shadow-cljs` `deps.edn`
+- `:clerk-sha`: the hash of the Clerk version you'd like to use in the template.
+  (`clerk-utils/custom` uses a [git
+  dependency](https://clojure.org/news/2018/01/05/git-deps) for Clerk.)
+- `:shadow-port`: the port that [`shadow-cljs`][shadow-url] uses to serve
+  compiled JavaScript during interactive development.
+- `:shadow-version`: the version of [`shadow-cljs`][shadow-url] required by the
+  generated project.
+- `:clj-version`: the version of Clojure required by the generated project.
+- `:cljs-version`: the version of ClojureScript required by the generated
+  project. (_note that this needs to meet or exceed the version declared in the
+  [`shadow-cljs` `deps.edn`
   file](https://github.com/thheller/shadow-cljs/blob/master/deps.edn) for the
   `shadow-cljs` version you've chosen._)
-- `:http-server-port`: (`8080`) The port used by `bb serve` and `bb
-  publish-local` to serve the local statically built site.
-- `:cname`: (`""`) If you're serving your GitHub Pages build from a custom URL,
-  pass the value (like `"clerk-utils.mentat.org"`) of the custom site via this
+- `:http-server-port`: The port used by `bb serve` and `bb publish-local` to
+  serve the local statically built site.
+- `:cname`: If you're serving your GitHub Pages build from a custom URL, pass
+  the value (like `"clerk-utils.mentat.org"`) of the custom site via this
   argument.
 
 ## Thanks and Support
@@ -87,3 +87,4 @@ Distributed under the [MIT License](LICENSE). See [LICENSE](LICENSE).
 [clerk-utils-url]: https://clerk-utils.mentat.org
 [deps-new-url]: https://github.com/seancorfield/deps-new
 [shadow-url]: https://shadow-cljs.github.io/docs/UsersGuide.html
+[template-edn-url]: https://github.com/mentat-collective/clerk-utils/blob/main/resources/clerk_utils/custom/template.edn

--- a/src/mentat/clerk_utils/show.cljc
+++ b/src/mentat/clerk_utils/show.cljc
@@ -78,7 +78,7 @@
           js/window
           [:show-cljs fn-name]
           (fn [x] (or x (reagent.core/atom {:loading? true}))))
-         (let [res @(j/get-in js/window [:show-cljs fn-name])]
+         (let [res @(applied-science.js-interop/get-in js/window [:show-cljs fn-name])]
            (if (:loading? res)
              [:div.show-cljs-loading
               {:style {:color "rgba(0,0,0,0.5)"}}

--- a/test/mentat/clerk_utils/show_test.clj
+++ b/test/mentat/clerk_utils/show_test.clj
@@ -1,0 +1,6 @@
+(ns mentat.clerk-utils.show-test
+  (:require [clojure.test :refer [is deftest testing]]))
+
+(deftest check-tests
+  (testing "numbers"
+    (is (= 1 1) "Hi!")))


### PR DESCRIPTION
- #21:

  - Adds `bb test`, GitHub Action for tests and the `deps.edn` entry required to
    make it work.

  - Fixes a `j/` alias left over in `mentat.clerk-utils.show/loading-viewer`;
    these aliases aren't available in the latest Clerk SCI environment, and need
    to be fully expanded.