### PR TITLE
`q` inside `show-sci`, remove babashka dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pom.xml.asc
 .lein-*
 .nrepl-*
 .DS_Store
+.cljs_node_repl
 
 .hgignore
 .hg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [unreleased]
 
+## [0.5.0]
+
+- #28:
+
+  - Removes the `babashka` dependency from `mentat.clerk-utils.build`
+
+  - `mentat.clerk-utils.show/q` now applies to the forms passed to `show-sci`,
+    allowing for value-splicing, namespace resolution etc inside of `show-sci`.
+
 - #24 renames the clj-kondo hooks to have extension `.clj_kondo`, for the same
   reason as #23.
 

--- a/build.clj
+++ b/build.clj
@@ -18,7 +18,7 @@
 ;; ## Variables
 
 (def lib 'org.mentat/clerk-utils)
-(def version "0.4.1")
+(def version "0.5.0")
 (def pom-deps
   {'io.github.nextjournal/clerk
    {:mvn/version "0.12.707"

--- a/dev/clerk_utils/notebook.clj
+++ b/dev/clerk_utils/notebook.clj
@@ -472,6 +472,20 @@ clojure -Sdeps '{:deps {io.github.mentat-collective/clerk-utils {:git/sha \"%s\"
 (show-sci
  [:pre (exclaim "Still here")])
 
+;; `show-sci` makes use of the [`q` macro](#q-macro-for-viewers) internally, so
+;; you can do thing like splice values in from your Clojure environment:
+
+(let [defaults {:key "value"}
+      entries  [1 2 3]]
+  (show-sci
+   [nextjournal.clerk.viewer/inspect
+    ;; The form passed to `inspect` uses values spliced in from the CLJ-side
+    ;; `let` form above.
+    [~defaults
+     [~@entries 4]]]))
+
+;; See the [`q` macro section](#q-macro-for-viewers) for more detail.
+
 ;; ### Client / Server Example
 ;;
 ;; Annotate a `var` definition bound to an atom with `^{::clerk/sync true}` to

--- a/src/mentat/clerk_utils/build.clj
+++ b/src/mentat/clerk_utils/build.clj
@@ -1,13 +1,14 @@
 (ns mentat.clerk-utils.build
   "Versions of `nextjournal.clerk/{build!,serve!,halt!} that support custom CLJS
   compilation.`"
-  (:require [babashka.fs :as fs]
+  (:require [clojure.java.io :as io]
             [mentat.clerk-utils.docs :refer [git-sha]]
             [mentat.clerk-utils.build.shadow :as shadow]
             [nextjournal.clerk :as clerk]
             [nextjournal.clerk.config :as config]
             [nextjournal.clerk.view]
-            [nextjournal.clerk.viewer :as cv]))
+            [nextjournal.clerk.viewer :as cv])
+  (:import (java.nio.file Files)))
 
 ;; ## Viewer JS Utilities
 
@@ -125,7 +126,8 @@
       (if-not (seq cljs-namespaces)
         @!build
         (let [js-path (shadow/release! cljs-namespaces)
-              cas     (->> (fs/read-all-bytes js-path)
+              cas     (->> (.toPath (io/file js-path))
+                           (Files/readAllBytes)
                            (cv/store+get-cas-url!
                             {:out-path out-path
                              :ext "js"}))]

--- a/src/mentat/clerk_utils/show.cljc
+++ b/src/mentat/clerk_utils/show.cljc
@@ -2,6 +2,7 @@
   "Show utilities for Clerk."
   (:require [applied-science.js-interop :as j]
             [clojure.walk :as walk]
+            #?(:clj [mentat.clerk-utils.viewers :refer [q]])
             [nextjournal.clerk #?(:clj :as :cljs :as-alias) clerk])
   #?(:cljs
      (:require-macros mentat.clerk-utils.show)))
@@ -17,18 +18,21 @@
 
   Works in both `clj` and `cljs` contexts; in `cljs` this is equivalent to
   `clojure.core/comment`."
-  [& exprs]
+  [& #?(:clj exprs :cljs _exprs)]
   (when-not (:ns &env)
-    `(clerk/with-viewer
-       {:transform-fn clerk/mark-presented
-        :render-fn
-        '(fn [_#]
-           (let [result# (do ~@exprs)]
-             (nextjournal.clerk.viewer/html
-              (if (vector? result#)
-                result#
-                [nextjournal.clerk.render/inspect result#]))))}
-       {})))
+    #?(:clj
+       `(clerk/with-viewer
+          {:transform-fn clerk/mark-presented
+           :render-fn
+           (q
+            (fn [_#]
+              (let [result# (do ~@exprs)]
+                (nextjournal.clerk.viewer/html
+                 (if (vector? result#)
+                   result#
+                   [nextjournal.clerk.render/inspect result#])))))}
+          {})
+       :cljs nil)))
 
 ;; ## show-cljs macro
 ;;


### PR DESCRIPTION
This PR:

  - Removes the `babashka` dependency from `mentat.clerk-utils.build`

  - `mentat.clerk-utils.show/q` now applies to the forms passed to `show-sci`,
    allowing for value-splicing, namespace resolution etc inside of `show-sci`.