### PR TITLE
convert clerk_utils.clj to cljc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [0.5.0]
 
+- #:
+
+  - `mentat.clerk-utils` is now a cljc file.
+
 - #28:
 
   - Removes the `babashka` dependency from `mentat.clerk-utils.build`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ## [0.5.0]
 
-- #:
-
-  - `mentat.clerk-utils` is now a cljc file.
+- #29 converts `mentat.clerk-utils` to `cljc`. The CLJS side doesn't do
+  anything, but this allows the require and macro calls to live inside `cljc`
+  files.
 
 - #28:
 


### PR DESCRIPTION
- #29 converts `mentat.clerk-utils` to `cljc`. The CLJS side doesn't do
  anything, but this allows the require and macro calls to live inside `cljc`
  files.