### PR TITLE
Backwards compatibility with static-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [unreleased]
 
-- #32
+## [0.5.1]
+
+- #32 modifies `mentat.clerk-utils.build.shadow` to include
+  `nextjournal.clerk.static-app` only when available, adding backwards
+  compatibility in for previous Clerk versions.
 
 - #31 upgrades Clerk in the project and the template to
   `"5e875e256a28a6deabf27bd6fc20f44cee5dad20"`, past the sha that removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [unreleased]
 
-- Upgrade Clerk in the project and the template to
+- #32
+
+- #31 upgrades Clerk in the project and the template to
   `"5e875e256a28a6deabf27bd6fc20f44cee5dad20"`, past the sha that removed
   `nextjournal.clerk.static-app` in favor of `nextjournal.clerk.sci-env`.
 

--- a/build.clj
+++ b/build.clj
@@ -18,7 +18,7 @@
 ;; ## Variables
 
 (def lib 'org.mentat/clerk-utils)
-(def version "0.5.0")
+(def version "0.5.1")
 (def pom-deps
   {'io.github.nextjournal/clerk
    {:mvn/version "0.12.707"

--- a/src/mentat/clerk_utils/build/shadow.clj
+++ b/src/mentat/clerk_utils/build/shadow.clj
@@ -2,6 +2,7 @@
   "Utilities for generating custom Clerk viewer CLJS builds via `shadow-cljs`."
   (:require [clojure.string]
             [clojure.java.shell :refer [sh]]
+            [clojure.java.io :as io]
             [shadow.cljs.devtools.config :as shadow.config]
             [shadow.cljs.devtools.server :as shadow.server]
             [shadow.cljs.devtools.server.runtime :as runtime]
@@ -38,6 +39,14 @@
   "Location of the generated JS code."
   (str output-dir "/main.js"))
 
+(defn clerk-entries
+  "Returns the sequence of (symbols representing) cljs namespaces required by the
+  loaded version of Clerk for interactive development and static publication."
+  []
+  (cond-> ['nextjournal.clerk.sci-env]
+    (io/resource "nextjournal/clerk/static_app.cljs")
+    (conj 'nextjournal.clerk.static-app)))
+
 (defn clerk-build-config
   "Given sequence `cljs-namespaces` of symbols naming ClojureScript namspaces,
   returns a `:builds` entry for a `shadow-cljs` build of Clerk's viewer JS.
@@ -45,8 +54,7 @@
   The resulting build will include all supplied namespaces, plus Clerk's
   `nextjournal.clerk.static-app` namespace.`"
   [cljs-namespaces]
-  (let [entries (into ['nextjournal.clerk.sci-env]
-                      cljs-namespaces)]
+  (let [entries (into (clerk-entries) cljs-namespaces)]
     {:build-id build-id
      :target :esm
      :runtime :browser


### PR DESCRIPTION
This PR adds backwards compatibility for clerk versions that DO still have `static-app` built in.