### PR TITLE
Skip NPM call if no deps.cljs deps are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+- #33 modifies `mentat.clerk-utils.build.shadow/install-npm-deps!` to skip
+  running an extra npm commnand if there are no uninstalled dependencies in any
+  `deps.cljs` files.
+
 ## [0.5.1]
 
 - #32 modifies `mentat.clerk-utils.build.shadow` to include

--- a/src/mentat/clerk_utils/build.clj
+++ b/src/mentat/clerk_utils/build.clj
@@ -139,25 +139,3 @@
       (finally
         (when cname
           (spit (str out-path "/CNAME") cname))))))
-
-(require '[nextjournal.clerk.analyzer :as analyzer])
-
-(defn freeze!
-  [{:keys [cljs-namespaces]}]
-  (when (seq cljs-namespaces)
-    (let [js-path (shadow/release! cljs-namespaces)
-          data    (->> (.toPath (io/file js-path))
-                       (Files/readAllBytes))
-          tag     (analyzer/sha2-base58 data)]
-      tag)))
-
-(comment
-  (let [data (Files/readAllBytes(.toPath (io/file "./template/pom.xml")))
-        tag  (analyzer/sha2-base58 data)]
-    ((requiring-resolve 'nextjournal.cas-client/cas-put)
-     {:path "template"
-      :auth-token "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"
-      #_(System/getenv "GITHUB_TOKEN")
-      :namespace "nextjournal"
-      :tag tag})
-    ))

--- a/src/mentat/clerk_utils/build.clj
+++ b/src/mentat/clerk_utils/build.clj
@@ -139,3 +139,25 @@
       (finally
         (when cname
           (spit (str out-path "/CNAME") cname))))))
+
+(require '[nextjournal.clerk.analyzer :as analyzer])
+
+(defn freeze!
+  [{:keys [cljs-namespaces]}]
+  (when (seq cljs-namespaces)
+    (let [js-path (shadow/release! cljs-namespaces)
+          data    (->> (.toPath (io/file js-path))
+                       (Files/readAllBytes))
+          tag     (analyzer/sha2-base58 data)]
+      tag)))
+
+(comment
+  (let [data (Files/readAllBytes(.toPath (io/file "./template/pom.xml")))
+        tag  (analyzer/sha2-base58 data)]
+    ((requiring-resolve 'nextjournal.cas-client/cas-put)
+     {:path "template"
+      :auth-token "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"
+      #_(System/getenv "GITHUB_TOKEN")
+      :namespace "nextjournal"
+      :tag tag})
+    ))

--- a/src/mentat/clerk_utils/build/shadow.clj
+++ b/src/mentat/clerk_utils/build/shadow.clj
@@ -97,7 +97,8 @@
        (:out
         (sh npm-cmd "install"))))
 
-    (npm-deps/install-deps {} deps)))
+    (when (seq deps)
+      (npm-deps/install-deps {} deps))))
 
 (defn stop-watch!
   "Shuts down the `shadow-cljs` server (if running) and stops the build watcher


### PR DESCRIPTION
- #33 modifies `mentat.clerk-utils.build.shadow/install-npm-deps!` to skip
  running an extra npm commnand if there are no uninstalled dependencies in any
  `deps.cljs` files.