### PR TITLE
Add release->cas! and custom JS bundle support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [unreleased]
 
+## [0.6.0]
+
+- #34:
+
+  - adds `mentat.clerk-utils.build/release->cas!` for sending compiled JS
+    bundles up to Garden.
+
+  -  adds `:custom-js` options to `mentat.clerk-utils.build/{build!, serve!}`
+     for specifying a different bundle than Clerk's built-in bundle (from
+     [Emmy-Viewers](https://github.com/mentat-collective/emmy-viewers), for
+     example)
+
 - #33 modifies `mentat.clerk-utils.build.shadow/install-npm-deps!` to skip
   running an extra npm commnand if there are no uninstalled dependencies in any
   `deps.cljs` files.


### PR DESCRIPTION
- #34:

  - adds `mentat.clerk-utils.build/release->cas!` for sending compiled JS
    bundles up to Garden.

  -  adds `:custom-js` options to `mentat.clerk-utils.build/{build!, serve!}`
     for specifying a different bundle than Clerk's built-in bundle (from
     [Emmy-Viewers](https://github.com/mentat-collective/emmy-viewers), for
     example)